### PR TITLE
feature: add monitoring

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    //monitoring
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+
     compileOnly 'org.projectlombok:lombok'
 
     runtimeOnly 'com.h2database:h2'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,5 +6,18 @@ services:
       - '8080:8080'
     depends_on:
       - redis
+      - prometheus
   redis:
     image: redis
+
+  prometheus:
+    image: prom/prometheus
+    ports:
+      - '9090:9090'
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+
+  grafana:
+    image: grafana/grafana
+    ports:
+      - '3000:3000'

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 10s # 10초 마다 Metric을 Pulling
+  evaluation_interval: 10s # rule 을 얼마나 빈번하게 검증하는지 설정
+scrape_configs:
+  - job_name: 'spring-actuator-prometheus'
+    metrics_path: '/cheffi-monitoring/prometheus' # Application prometheus endpoint
+    static_configs:
+      - targets: ['host.docker.internal:8080'] # Application host:port #linux 환경에서는 172.17.0.2

--- a/src/main/java/com/cheffi/common/config/actuator/ActuatorConfig.java
+++ b/src/main/java/com/cheffi/common/config/actuator/ActuatorConfig.java
@@ -1,0 +1,17 @@
+package com.cheffi.common.config.actuator;
+
+import org.springframework.boot.actuate.web.exchanges.InMemoryHttpExchangeRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Actuator endpoint bean등록 예시
+ */
+@Configuration
+public class ActuatorConfig {
+
+	@Bean
+	public InMemoryHttpExchangeRepository createTraceRepository() {
+		return new InMemoryHttpExchangeRepository();
+	}
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -27,3 +27,30 @@ spring:
 
 api:
   prefix: /api/v1
+
+
+# monitoring setting start
+management:
+  #  server:
+  #    port: 50000
+  endpoint:
+    httpexchanges:
+      enabled: true
+    metrics:
+      enabled: true
+    prometheus:
+      enabled: true
+  endpoints:
+    web:
+      base-path: /cheffi-monitoring
+      exposure:
+        include:
+          - health
+          - info
+          - beans
+          - conditions
+          - httpexchanges
+          - metrics
+          - prometheus
+          - configprops
+# monitoring setting end

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,3 +32,29 @@ spring:
 
 api:
   prefix: /api/v1
+
+# monitoring setting start
+management:
+  #  server:
+  #    port: 50000
+  endpoint:
+    httpexchanges:
+      enabled: true
+    metrics:
+      enabled: true
+    prometheus:
+      enabled: true
+  endpoints:
+    web:
+      base-path: /cheffi-monitoring
+      exposure:
+        include:
+        - health
+        - info
+        - beans
+        - conditions
+        - httpexchanges
+        - metrics
+        - prometheus
+        - configprops
+# monitoring setting end


### PR DESCRIPTION
Springboot + 프로메테우스 + 그라파나 연동까지 성공

블로그에 나오는 설정정보는 아래 문서에서 확인했고 (공식문서 2-1 ~ 2-2 Endpoint부분만 참조)
https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html#actuator.enabling

actuator사용하면서 유의할점은 기술블로그 참조
https://techblog.woowahan.com/9232/

아래 사진처럼 springboot의 actuator에서 제공하는 데이터를
프로메테우스가 가져오고
그라파나는 프로메테우스 데이터를 가져올수 있도록 연결된상태인데

맨위의 링크에서 제공하는 actuator의 엔드포인트활용해서 어떤 값 가져와야하는지
프로메테우스에서 그 값을 어떻게 조회하는지
그라파나는 대쉬보드 하나 다운받아서 시각화하는지 알아본뒤에 다시 설정해서 올리겠습니다

<img width="880" alt="Screenshot 2023-08-14 at 6 23 04 PM" src="https://github.com/Cheffi-Git/Cheffi-Server/assets/84488007/60ee8a73-4366-4317-9fef-b6067f1afc32">
