### PR TITLE
Fix :cicd

### DIFF
--- a/.github/workflows/deploy_dev_ec2.yml
+++ b/.github/workflows/deploy_dev_ec2.yml
@@ -3,7 +3,7 @@ name: Deploy to EC2
 on:
   push:
     branches:
-      - hotfix/CICD
+      - develop
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
jobs의 deploy단계가 추가되면서

새롭게 ubuntu container가 실행되는 바람에 scp에 전송할 파일이 없어 배포오류 발생

build-artifacts, actions/upload-artifact@v2 를 사용해
build단계에서 필요한 파일을 deploy단계의 ubuntu container로 넘겨주는 형태로 수정했습니다.