### PR TITLE
Feat: add codes to allow IP of GHA runner to EC2 security group when …

### DIFF
--- a/.github/workflows/deploy_dev_ec2.yml
+++ b/.github/workflows/deploy_dev_ec2.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - feature/config/ec2/security-group
   workflow_dispatch:
 
 jobs:
@@ -68,6 +69,23 @@ jobs:
         with:
           name: build-artifacts
 
+      - name: Get Github action IP
+        id: ip
+        uses: haythem/public-ip@v1.2
+
+      - name: Setting environment variables..
+        run: |
+          echo "AWS_DEFAULT_REGION=ap-northeast-1" &gt;&gt; $GITHUB_ENV
+          echo "AWS_SG_NAME=dev-ec2-security-group" &gt;&gt; $GITHUB_ENV
+
+      - name: Add Github Actions IP to Security group
+        run: |
+          aws ec2 authorize-security-group-ingress --group-name ${{ env.AWS_SG_NAME }} --protocol tcp --port 22 --cidr ${{ steps.ip.outputs.ipv4 }}/32
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ env.AWS_DEFAULT_REGION }}
+
       - name: SCP JAR to EC2
         uses: appleboy/scp-action@master
         with:
@@ -88,6 +106,15 @@ jobs:
             docker-compose down --rmi local
             docker image prune -f
             docker-compose up --build -d
+
+      - name: Remove Github Actions IP from security group
+        run: |
+          aws ec2 revoke-security-group-ingress --group-name ${{ env.AWS_SG_NAME }} --protocol tcp --port 22 --cidr ${{ steps.ip.outputs.ipv4 }}/32
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ env.AWS_DEFAULT_REGION }}
+        if: always()
 
       - name: Deployment Success Notification
         uses: 8398a7/action-slack@v3


### PR DESCRIPTION
Feat: add codes to allow IP of GHA runner to EC2 security group when deploying

need to allow accessing from GHA runner because in order to deploy, GHA runner will try to access EC2 instance with SSH protocol. So, I added the codes modifying the security groups applied to EC2(where the development server runs)  in GHA deploying scripts.