### PR TITLE
Hotfix: fix bugs of `GET /reviews/areas` API

### DIFF
--- a/src/main/java/com/cheffi/common/code/ErrorCode.java
+++ b/src/main/java/com/cheffi/common/code/ErrorCode.java
@@ -56,6 +56,7 @@ public enum ErrorCode {
 	ALREADY_BOOKMARKED(HttpStatus.BAD_REQUEST, "R-007", "유저가 해당 리뷰를 이미 북마크했습니다."),
 	NOT_BOOKMARKED(HttpStatus.BAD_REQUEST, "R-008", "유저가 해당 리뷰를 북마크 하지 않았습니다."),
 	ADDRESS_NOT_EXIST(HttpStatus.BAD_REQUEST, "R-009", "존재하지 않는 주소입니다."),
+	REVIEW_NOT_EXIST_IN_AREA(HttpStatus.BAD_REQUEST, "R-010", "해당 지역에 등록된 리뷰가 없습니다."),
 
 	// 파일
 	NOT_IMAGE_FILE(HttpStatus.BAD_REQUEST, "F-001", "전송된 파일의 형식이 이미지가 아닙니다."),

--- a/src/main/java/com/cheffi/review/constant/ReviewStatus.java
+++ b/src/main/java/com/cheffi/review/constant/ReviewStatus.java
@@ -1,0 +1,7 @@
+package com.cheffi.review.constant;
+
+public enum ReviewStatus {
+
+	ACTIVE, DELETED, BANNED
+
+}

--- a/src/main/java/com/cheffi/review/controller/ReviewController.java
+++ b/src/main/java/com/cheffi/review/controller/ReviewController.java
@@ -6,7 +6,6 @@ import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -34,7 +33,6 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 
-@Validated
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("${api.prefix}/reviews")

--- a/src/main/java/com/cheffi/review/domain/Review.java
+++ b/src/main/java/com/cheffi/review/domain/Review.java
@@ -11,10 +11,13 @@ import com.cheffi.common.code.ErrorCode;
 import com.cheffi.common.config.exception.business.BusinessException;
 import com.cheffi.common.domain.BaseTimeEntity;
 import com.cheffi.review.constant.RatingType;
+import com.cheffi.review.constant.ReviewStatus;
 import com.cheffi.tag.domain.Tag;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -47,6 +50,9 @@ public class Review extends BaseTimeEntity {
 	private LocalDateTime timeToLock;
 	private int viewCnt;
 
+	@NotNull
+	@Enumerated(EnumType.STRING)
+	private ReviewStatus status;
 	@NotNull
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "restaurant_id")
@@ -82,6 +88,7 @@ public class Review extends BaseTimeEntity {
 		this.averageRatingCnt = 0;
 		this.badRatingCnt = 0;
 		this.viewCnt = 0;
+		this.status = ReviewStatus.ACTIVE;
 	}
 
 	public static Review of(ReviewCreateRequest request, Restaurant restaurant, Avatar writer) {

--- a/src/main/java/com/cheffi/review/dto/ReviewInfoDto.java
+++ b/src/main/java/com/cheffi/review/dto/ReviewInfoDto.java
@@ -3,6 +3,7 @@ package com.cheffi.review.dto;
 import java.time.Duration;
 import java.time.LocalDateTime;
 
+import com.cheffi.review.constant.ReviewStatus;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.querydsl.core.annotations.QueryProjection;
@@ -30,13 +31,23 @@ public class ReviewInfoDto {
 	private boolean locked;
 	@Schema(description = "북마크 여부", example = "true")
 	private Boolean bookmarked;
+	@Schema(description = "누적 조회수", example = "100")
 	private Integer viewCount;
+	@Schema(description = "랭킹(커서)", example = "10")
 	private Integer number;
+	@Schema(description = "리뷰의 현재 상태", example = "ACTIVE")
+	private ReviewStatus reviewStatus;
+	@Schema(description = "리뷰의 활성화 여부 'ACTIVE' 상태이면 true", example = "true")
+	private boolean active;
 
 	@QueryProjection
 	public ReviewInfoDto(Long id, String title, String text, ReviewPhotoInfoDto photo,
-		LocalDateTime timeToLock, Boolean bookmarked, Integer viewCount) {
+		LocalDateTime timeToLock, Boolean bookmarked, Integer viewCount, ReviewStatus reviewStatus) {
+		this.reviewStatus = reviewStatus;
 		this.id = id;
+		if (!ReviewStatus.ACTIVE.equals(reviewStatus))
+			return;
+		this.active = true;
 		this.title = title;
 		this.text = text;
 		this.photo = photo;

--- a/src/main/java/com/cheffi/review/repository/ReviewJpaRepository.java
+++ b/src/main/java/com/cheffi/review/repository/ReviewJpaRepository.java
@@ -30,7 +30,7 @@ public class ReviewJpaRepository {
 	}
 
 	public List<ReviewInfoDto> findAllById(List<Long> ids) {
-		if(ids.isEmpty())
+		if (ids.isEmpty())
 			return List.of();
 
 		JPAQuery<ReviewInfoDto> query = queryFactory
@@ -41,7 +41,8 @@ public class ReviewJpaRepository {
 				new QReviewPhotoInfoDto(reviewPhoto.id, reviewPhoto.givenOrder, reviewPhoto.url),
 				review.timeToLock,
 				Expressions.FALSE,
-				review.viewCnt
+				review.viewCnt,
+				review.status
 			))
 			.from(review)
 			.leftJoin(review.photos, reviewPhoto)
@@ -52,7 +53,7 @@ public class ReviewJpaRepository {
 	}
 
 	public List<ReviewInfoDto> findAllByIdWithBookmark(List<Long> ids, Long viewerId) {
-		if(ids.isEmpty())
+		if (ids.isEmpty())
 			return List.of();
 
 		JPAQuery<ReviewInfoDto> query = queryFactory
@@ -63,7 +64,8 @@ public class ReviewJpaRepository {
 				new QReviewPhotoInfoDto(reviewPhoto.id, reviewPhoto.givenOrder, reviewPhoto.url),
 				review.timeToLock,
 				bookmark.isNotNull(),
-				review.viewCnt
+				review.viewCnt,
+				review.status
 			))
 			.from(review)
 			.leftJoin(review.photos, reviewPhoto)

--- a/src/main/java/com/cheffi/review/repository/ReviewRepository.java
+++ b/src/main/java/com/cheffi/review/repository/ReviewRepository.java
@@ -13,7 +13,9 @@ import com.cheffi.review.domain.Review;
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 	@Query("""
 		select r from Review r
-		where r.restaurant.detailedAddress.province = :province and r.restaurant.detailedAddress.city = :city""")
+		where r.restaurant.detailedAddress.province = :province 
+		and r.restaurant.detailedAddress.city = :city
+		and r.status = 'ACTIVE'""")
 	List<Review> findByCity(@Param("province") @NonNull String province,
 		@Param("city") @NonNull String city);
 

--- a/src/main/java/com/cheffi/review/service/ReviewRankingService.java
+++ b/src/main/java/com/cheffi/review/service/ReviewRankingService.java
@@ -8,7 +8,10 @@ import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.cheffi.common.code.ErrorCode;
+import com.cheffi.common.config.exception.business.BusinessException;
 import com.cheffi.common.constant.Address;
+import com.cheffi.review.domain.Review;
 import com.cheffi.review.domain.ReviewRanking;
 
 import lombok.RequiredArgsConstructor;
@@ -24,7 +27,10 @@ public class ReviewRankingService {
 
 	@Transactional(readOnly = true)
 	public Set<ZSetOperations.TypedTuple<Object>> calculateRanking(Address address, LocalDateTime from, LocalDateTime to) {
-		ReviewRanking reviewRanking = new ReviewRanking(reviewService.getByAddress(address));
+		List<Review> queriedReviews = reviewService.getByAddress(address);
+		if(queriedReviews.isEmpty())
+			throw new BusinessException(ErrorCode.REVIEW_NOT_EXIST_IN_AREA);
+		ReviewRanking reviewRanking = new ReviewRanking(queriedReviews);
 
 		List<Long> ids = reviewRanking.getIds();
 		reviewRanking.includeScore(ratingService.getRatingScoreBetween(ids, from, to));


### PR DESCRIPTION
1. throw error message, if there is no review in specific area
2. server will cache only reviews which are active
3. if a already cached review is deleted or banned, server won't give the details about the review

Related to #81 
