### PR TITLE
Hotfix: change documents' query parameter `tagId`

### DIFF
--- a/src/main/java/com/cheffi/review/dto/request/AreaTagSearchRequest.java
+++ b/src/main/java/com/cheffi/review/dto/request/AreaTagSearchRequest.java
@@ -33,7 +33,7 @@ public class AreaTagSearchRequest implements RedisZSetRequest {
 	@Range(min = 1, max = 16)
 	private final Integer size;
 
-	@Parameter(description = "검색할 태그의 인덱스, 음식 태그만 입력 가능합니다.", example = "15")
+	@Parameter(name = "tag_id", description = "검색할 태그의 인덱스, 음식 태그만 입력 가능합니다.", example = "15")
 	@NotNull
 	private final Long tagId;
 	@JsonIgnore


### PR DESCRIPTION
change documents' invalid query parameter `tagId` into `tag_id` on swagger