### PR TITLE
Feat: add `@JsonInclude` to include only nonnull fields

### DIFF
--- a/src/main/java/com/cheffi/common/response/ApiPageResponse.java
+++ b/src/main/java/com/cheffi/common/response/ApiPageResponse.java
@@ -11,8 +11,8 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
-@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
 @Getter
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class ApiPageResponse<T> {
 
 	@Schema(description = "데이터")

--- a/src/main/java/com/cheffi/common/response/ErrorResponse.java
+++ b/src/main/java/com/cheffi/common/response/ErrorResponse.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
@@ -16,6 +17,7 @@ import lombok.Getter;
 
 @Getter
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class ErrorResponse {
 


### PR DESCRIPTION
# 에러 응답시 `data` 필드가 null이면 Json으로 응답하지 않도록 설정