### PR TITLE
Feat: change logic of checking `Notification`

### DIFF
--- a/src/main/java/com/cheffi/notification/repository/NotificationJpaRepository.java
+++ b/src/main/java/com/cheffi/notification/repository/NotificationJpaRepository.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Repository;
 
 import com.cheffi.notification.domain.Notification;
 import com.cheffi.notification.dto.GetNotificationRequest;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
@@ -35,4 +36,10 @@ public class NotificationJpaRepository {
 		return query.fetch();
 	}
 
+	public Long updateCheckedAllByAvatar(Long avatarId) {
+		return queryFactory.update(notification)
+			.set(notification.checked, Expressions.TRUE)
+			.where(notification.avatar.id.eq(avatarId))
+			.execute();
+	}
 }

--- a/src/main/java/com/cheffi/notification/service/NotificationService.java
+++ b/src/main/java/com/cheffi/notification/service/NotificationService.java
@@ -25,15 +25,13 @@ public class NotificationService {
 
 	@Transactional
 	public CursorPage<NotificationDto, Long> getNotifications(GetNotificationRequest request, Long avatarId) {
-		List<Notification> notifications = notificationJpaRepository.findByAvatar(request, avatarId);
-		List<NotificationDto> result = notifications.stream().map(NotificationDto::of).toList();
+		List<NotificationDto> result = notificationJpaRepository.findByAvatar(request, avatarId)
+			.stream()
+			.map(NotificationDto::of)
+			.toList();
+		notificationJpaRepository.updateCheckedAllByAvatar(avatarId);
 
-		notifications.stream()
-			.filter(Notification::isUnchecked)
-			.forEach(Notification::check);
-
-		return CursorPage.of(result, request.getSize(),
-			NotificationDto::id);
+		return CursorPage.of(result, request.getSize(), NotificationDto::id);
 	}
 
 	@Transactional


### PR DESCRIPTION
# 알림 관련 로직 변경

> (기존) 알림을 커서페이징으로 조회하고 조회한 알림 레코드만 `확인` 상태로 변경
- 변경 감지 기능 사용

> (변경) 알림을 커서페이징으로 조회하고 해당 유저의 모든 알림 레코드를 `확인` 상태로 변경
- 벌크 업데이트 쿼리 처리

Related to #158 