### PR TITLE
Feat: send notifications to target of follow

### DIFF
--- a/src/main/java/com/cheffi/avatar/controller/FollowController.java
+++ b/src/main/java/com/cheffi/avatar/controller/FollowController.java
@@ -10,11 +10,14 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.cheffi.avatar.dto.GetFollowRequest;
+import com.cheffi.avatar.dto.request.DeleteFollowRequest;
+import com.cheffi.avatar.dto.request.PostFollowRequest;
 import com.cheffi.avatar.dto.response.AddFollowResponse;
 import com.cheffi.avatar.dto.response.GetFollowResponse;
 import com.cheffi.avatar.dto.response.RecommendFollowResponse;
@@ -47,8 +50,8 @@ public class FollowController {
 	@PostMapping
 	public ApiResponse<AddFollowResponse> addFollow(
 		@AuthenticationPrincipal UserPrincipal principal,
-		@Positive Long avatarId) {
-		return ApiResponse.success(followService.addFollow(principal.getAvatarId(), avatarId));
+		@Valid @RequestBody PostFollowRequest request) {
+		return ApiResponse.success(followService.addFollow(principal.getAvatarId(), request.id()));
 	}
 
 	@Tag(name = "${swagger.tag.follow}")
@@ -59,9 +62,8 @@ public class FollowController {
 	@DeleteMapping
 	public ApiResponse<UnfollowResponse> unfollow(
 		@AuthenticationPrincipal UserPrincipal principal,
-		@Positive Long avatarId) {
-
-		return ApiResponse.success(followService.unfollow(principal.getAvatarId(), avatarId));
+		@Valid @RequestBody DeleteFollowRequest request) {
+		return ApiResponse.success(followService.unfollow(principal.getAvatarId(), request.id()));
 	}
 
 	@Tag(name = "${swagger.tag.follow}")

--- a/src/main/java/com/cheffi/avatar/dto/request/DeleteFollowRequest.java
+++ b/src/main/java/com/cheffi/avatar/dto/request/DeleteFollowRequest.java
@@ -1,0 +1,10 @@
+package com.cheffi.avatar.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Positive;
+
+public record DeleteFollowRequest(
+	@Schema(description = "팔로우 취소할 유저의 ID")
+	@Positive Long id
+) {
+}

--- a/src/main/java/com/cheffi/avatar/dto/request/PostFollowRequest.java
+++ b/src/main/java/com/cheffi/avatar/dto/request/PostFollowRequest.java
@@ -1,0 +1,10 @@
+package com.cheffi.avatar.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Positive;
+
+public record PostFollowRequest(
+	@Schema(description = "팔로우할 유저의 ID")
+	@Positive Long id
+) {
+}

--- a/src/main/java/com/cheffi/event/event/FollowEvent.java
+++ b/src/main/java/com/cheffi/event/event/FollowEvent.java
@@ -1,0 +1,17 @@
+package com.cheffi.event.event;
+
+import com.cheffi.avatar.domain.Avatar;
+
+import lombok.Getter;
+
+@Getter
+public class FollowEvent {
+
+	private final Long targetId;
+	private final String subjectNickname;
+
+	public FollowEvent(Avatar target, Avatar subject) {
+		this.targetId = target.getId();
+		this.subjectNickname = subject.getNickname();
+	}
+}

--- a/src/main/java/com/cheffi/event/listener/FollowEventListener.java
+++ b/src/main/java/com/cheffi/event/listener/FollowEventListener.java
@@ -1,0 +1,24 @@
+package com.cheffi.event.listener;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.cheffi.event.event.FollowEvent;
+import com.cheffi.notification.service.NotificationService;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Component
+public class FollowEventListener {
+
+	private final NotificationService notificationService;
+
+	@Async
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, classes = FollowEvent.class)
+	public void onReviewCreation(FollowEvent event) {
+		notificationService.notifyFollow(event.getTargetId(), event.getSubjectNickname());
+	}
+}

--- a/src/main/java/com/cheffi/notification/domain/Notification.java
+++ b/src/main/java/com/cheffi/notification/domain/Notification.java
@@ -56,4 +56,9 @@ public class Notification extends BaseEntity {
 		return new Notification(NotificationCategory.OFFICIAL, target, title);
 	}
 
+	public static Notification ofFollow(Avatar target, String nickname) {
+		return new Notification(NotificationCategory.FOLLOW, target, nickname);
+	}
+
+
 }

--- a/src/main/java/com/cheffi/notification/service/NotificationService.java
+++ b/src/main/java/com/cheffi/notification/service/NotificationService.java
@@ -69,4 +69,9 @@ public class NotificationService {
 			.map(avatar -> Notification.ofOfficial(avatar, title)).toList();
 		notificationJdbcRepository.saveAll(notifications, "Official review create event");
 	}
+
+	@Transactional
+	public void notifyFollow(Long targetId, String subjectNickname) {
+		notificationRepository.save(Notification.ofFollow(avatarService.getById(targetId), subjectNickname));
+	}
 }

--- a/src/test/java/com/cheffi/avatar/service/FollowServiceTest.java
+++ b/src/test/java/com/cheffi/avatar/service/FollowServiceTest.java
@@ -14,6 +14,7 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 import com.cheffi.avatar.domain.Avatar;
 import com.cheffi.avatar.domain.Follow;
@@ -38,6 +39,8 @@ class FollowServiceTest {
 	private FollowJpaRepository followJpaRepository;
 	@Mock
 	private AvatarJpaRepository avatarJpaRepository;
+	@Mock
+	private ApplicationEventPublisher eventPublisher;
 
 	private AvatarService avatarService;
 
@@ -56,7 +59,7 @@ class FollowServiceTest {
 	@BeforeEach
 	void setUp() {
 		avatarService = new AvatarService(avatarRepository, avatarJpaRepository, profilePhotoService);
-		followService = new FollowService(followRepository, followJpaRepository, avatarService);
+		followService = new FollowService(followRepository, followJpaRepository, avatarService, eventPublisher);
 	}
 
 	@Nested


### PR DESCRIPTION
# 팔로우 시 팔로우 대상에게 알림 로직 추가

- 팔로우 시 팔로우 대상에게 알림 로직 추가
- 팔로우 등록, 취소 API가 쿼리 파라미터가 아닌 http body로 받도록 변경

Related to #158 