### PR TITLE
Fix: change left join to inner join

### DIFF
--- a/src/main/java/com/cheffi/review/repository/ReviewJpaRepository.java
+++ b/src/main/java/com/cheffi/review/repository/ReviewJpaRepository.java
@@ -59,7 +59,7 @@ public class ReviewJpaRepository {
 			.where(
 				restaurantAddressEq(condition.getAddress())
 			)
-			.leftJoin(review)
+			.join(review)
 			.on(restaurant.eq(review.restaurant));
 
 		Long tagId = condition.getTagId();


### PR DESCRIPTION
# 식당의 리뷰가 없을 경우 발생하는 에러 해결

### 현상 
findByCondition의 반환값인 List<Review> 내부에 `null`인 element가 발견되는 현상

### 원인 
기존 쿼리에서 `restaurant` 테이블에 등록되어 있지만 `review`가 없는 `restaurant`의 경우 left join으로 null인 레코드 쿼리됨

### 해결
`left join` -> `(inner) join`으로 변경해 null인 레코드가 쿼리되지 않도록 수정
