### PR TITLE
[Feat] minor patch with signing up

### DIFF
--- a/src/main/java/com/cheffi/avatar/domain/Avatar.java
+++ b/src/main/java/com/cheffi/avatar/domain/Avatar.java
@@ -94,8 +94,10 @@ public class Avatar extends BaseTimeEntity {
 	}
 
 	public void changeIntroduction(String introduction) {
-		if (!StringUtils.hasText(introduction))
-			throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
+		if (!StringUtils.hasText(introduction)) {
+			this.introduction = null;
+			return;
+		}
 		if (introduction.length() < 10 || introduction.length() > 50)
 			throw new BusinessException(ErrorCode.INVALID_INTRO_LENGTH);
 		this.introduction = introduction;

--- a/src/main/java/com/cheffi/avatar/domain/Nickname.java
+++ b/src/main/java/com/cheffi/avatar/domain/Nickname.java
@@ -2,6 +2,8 @@ package com.cheffi.avatar.domain;
 
 import java.io.Serializable;
 import java.time.LocalDate;
+import java.util.List;
+import java.util.Random;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.springframework.util.StringUtils;
@@ -29,6 +31,10 @@ import lombok.NoArgsConstructor;
 @Getter
 @Embeddable
 public class Nickname implements Serializable {
+
+	private static final List<String> BANNED_WORDS = List.of("쉐피");
+	private static final List<String> DEFAULT_WORDS = List.of("도토리", "완두콩", "단호박", "떡볶이", "인절미");
+	private static final Random random = new Random();
 
 	@Schema(description = "닉네임", example = "동구밭에서캔감자", required = true)
 	@Size(min = 2, max = 8)
@@ -59,7 +65,7 @@ public class Nickname implements Serializable {
 	private void validateNickname(String newNickname) {
 		if (!StringUtils.hasText(newNickname))
 			throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
-		if (newNickname.contains("쉐피"))
+		if (BANNED_WORDS.stream().anyMatch(newNickname::contains))
 			throw new BusinessException(ErrorCode.NICKNAME_CONTAINS_BANNED_WORDS);
 		if (!isChangeable())
 			throw new BusinessException(ErrorCode.CANNOT_CHANGE_NICKNAME_YET);
@@ -68,7 +74,7 @@ public class Nickname implements Serializable {
 	}
 
 	private static String getRandomNickname() {
-		return RandomStringUtils.randomNumeric(6) + "쉐피";
+		return DEFAULT_WORDS.get(random.nextInt(DEFAULT_WORDS.size())) + RandomStringUtils.randomNumeric(5);
 	}
 
 	@Schema(description = "응답일자 기준 닉네임 변경가능 여부", required = true)

--- a/src/main/java/com/cheffi/avatar/dto/request/PhotoTabChangeRequest.java
+++ b/src/main/java/com/cheffi/avatar/dto/request/PhotoTabChangeRequest.java
@@ -3,6 +3,7 @@ package com.cheffi.avatar.dto.request;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
@@ -12,6 +13,7 @@ public record PhotoTabChangeRequest(
 	@Schema(name = "default")
 	Boolean defaultPhoto,
 
+	@Nullable
 	@Size(min = 10, max = 50)
 	String introduction
 ) {

--- a/src/main/java/com/cheffi/avatar/service/AvatarService.java
+++ b/src/main/java/com/cheffi/avatar/service/AvatarService.java
@@ -62,6 +62,7 @@ public class AvatarService {
 		}
 		if (isNicknameInUse(avatar.stringNickname()))
 			throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
+		profilePhotoService.addDefaultPhoto(avatar);
 		return avatarRepository.save(avatar);
 	}
 

--- a/src/main/java/com/cheffi/avatar/service/AvatarService.java
+++ b/src/main/java/com/cheffi/avatar/service/AvatarService.java
@@ -97,8 +97,7 @@ public class AvatarService {
 	public boolean checkIfCompleteProfile(Long avatarId) {
 		Avatar avatar = getByIdWithTagsAndPhoto(avatarId);
 		return avatar.hasTags() &&
-			   avatar.hasPhoto() &&
-			   !avatar.stringNickname().contains("쉐피");
+			   avatar.hasPhoto();
 	}
 
 	public AvatarInfoResponse getAvatarInfo(Long avatarId) {


### PR DESCRIPTION
- #205 
- #191 

## 내용
- 회원가입시 기본 프로필 사진 설정
- 회원가입시 기본 닉네임 변경
- `/photo-tab` API의 `introduction`(자기소개) 필드 null 허용

