### PR TITLE
[Fix] fix wrong `QClass` mapping

### DIFF
--- a/src/main/java/com/cheffi/review/repository/querydsl/ReviewQueryProcessor.java
+++ b/src/main/java/com/cheffi/review/repository/querydsl/ReviewQueryProcessor.java
@@ -5,6 +5,7 @@ import static com.cheffi.review.domain.QReviewPhoto.*;
 
 import com.cheffi.avatar.domain.QPurchasedItem;
 import com.cheffi.review.constant.ReviewStatus;
+import com.cheffi.review.domain.QBookmark;
 import com.cheffi.review.dto.QReviewInfoDto;
 import com.cheffi.review.dto.QReviewPhotoInfoDto;
 import com.cheffi.review.dto.ReviewInfoDto;
@@ -16,7 +17,7 @@ import com.querydsl.jpa.impl.JPAQuery;
 public class ReviewQueryProcessor {
 
 	private static final QPurchasedItem viewerPurchase = new QPurchasedItem("viewerPurchase");
-	private static final QPurchasedItem viewerBookmark = new QPurchasedItem("viewerBookmark");
+	private static final QBookmark viewerBookmark = new QBookmark("viewerBookmark");
 
 	private final Long viewerId;
 	private final boolean requestBookmark;


### PR DESCRIPTION
# 리뷰 조회시 북마크 여부가 정상적으로 표시되지 않는 버그 수정

- `QBookmark`가 아니라 `QPurchasedItem`이 잘못 매핑되어 `bookmark` 테이블에 Left Join이 수행되지 않았고, 결과적으로 북마크가 정상적으로 표시되지 않음
- QClass 매핑을 정상적으로 변경해 해결
- #221 